### PR TITLE
Add timeout to http client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.12"
+  - "1.15"
 
 env: GO111MODULE=on
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ func main() {
 }
 ```
 
+## Options
+
+Configuration can be set on the constructor:
+
+```go
+m := mocker.New("http://localhost:3000", func(mm *Mocker) {
+  mm.Client = &http.Client{Timeout: time.Second}
+})
+```
+
+Or use some of the predefined options:
+
+## WithHTTPClient
+
+```go
+cli := &http.Client{Timeout: time.Second}
+m := mocker.New("http://localhost:3000", mocker.WithHTTPClient(cli))
+```
+
 ## License
 
 [MIT](/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ricardogama/api-mocker-go/v2
 
-go 1.12
+go 1.15
 
 require (
 	github.com/golang/mock v1.4.0

--- a/mocker.go
+++ b/mocker.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Request is a request that can be expected by the mock server.
@@ -38,12 +39,16 @@ type Results struct {
 // Mocker allows to communicate with a mock server.
 type Mocker struct {
 	BasePath string
+	Client   *http.Client
 }
 
 // New returns a new Mocker.
 func New(basePath string) *Mocker {
 	return &Mocker{
 		basePath,
+		&http.Client{
+			Timeout: time.Second,
+		},
 	}
 }
 
@@ -55,7 +60,7 @@ func (ms *Mocker) Results() (*Results, error) {
 		return nil, err
 	}
 
-	rsp, err := http.DefaultClient.Do(req)
+	rsp, err := ms.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +123,7 @@ func (ms *Mocker) Expect(mock *Request) error {
 	}
 
 	req.Header.Set("content-type", "application/json")
-	rsp, err := http.DefaultClient.Do(req)
+	rsp, err := ms.Client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -142,7 +147,7 @@ func (ms *Mocker) Clear() error {
 		return err
 	}
 
-	rsp, err := http.DefaultClient.Do(req)
+	rsp, err := ms.Client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/mocker.go
+++ b/mocker.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // Request is a request that can be expected by the mock server.
@@ -20,7 +19,7 @@ type Request struct {
 	Times    int                 `json:"times,omitempty"`
 	Query    map[string][]string `json:"query,omitempty"`
 	Response *Response           `json:"response"`
-	Anytime  bool                `json:"anytime"`
+	Anytime  bool                `json:"anytime,omitempty"`
 }
 
 // Response is a response that can be expected as a response to a mock request.
@@ -42,14 +41,26 @@ type Mocker struct {
 	Client   *http.Client
 }
 
-// New returns a new Mocker.
-func New(basePath string) *Mocker {
-	return &Mocker{
-		basePath,
-		&http.Client{
-			Timeout: time.Second,
-		},
+// Option allows setting config.
+type Option func(m *Mocker)
+
+// WithHTTPClient sets the http client.
+func WithHTTPClient(cli *http.Client) Option {
+	return func(m *Mocker) {
+		m.Client = cli
 	}
+}
+
+// New returns a new Mocker.
+func New(basePath string, opts ...Option) *Mocker {
+	m := &Mocker{
+		basePath,
+		&http.Client{},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 // Results returns both the expected and the unexpected results.

--- a/mocker_test.go
+++ b/mocker_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/ricardogama/api-mocker-go/testdata"
@@ -21,6 +22,30 @@ func Test_New(t *testing.T) {
 			So(mocker, ShouldResemble, &Mocker{
 				BasePath: "foo",
 				Client:   http.DefaultClient,
+			})
+		})
+
+		Convey("Sets the given options", func() {
+			mocker := New("foo", func(m *Mocker) {
+				m.Client = &http.Client{Timeout: time.Second}
+			})
+
+			So(mocker, ShouldResemble, &Mocker{
+				BasePath: "foo",
+				Client:   &http.Client{Timeout: time.Second},
+			})
+		})
+	})
+}
+
+func Test_WithHTTPClient(t *testing.T) {
+	Convey("New()", t, func() {
+		Convey("Sets the given client", func() {
+			mocker := New("foo", WithHTTPClient(&http.Client{Timeout: time.Second}))
+
+			So(mocker, ShouldResemble, &Mocker{
+				BasePath: "foo",
+				Client:   &http.Client{Timeout: time.Second},
 			})
 		})
 	})

--- a/mocker_test.go
+++ b/mocker_test.go
@@ -20,6 +20,7 @@ func Test_New(t *testing.T) {
 
 			So(mocker, ShouldResemble, &Mocker{
 				BasePath: "foo",
+				Client:   http.DefaultClient,
 			})
 		})
 	})
@@ -33,18 +34,18 @@ func Test_Mocker_Results(t *testing.T) {
 
 	Convey("*Mocker.Results()", t, func() {
 		Convey("Returns an error when it's not possible to create a request", func() {
-			mock := &Mocker{BasePath: ":"}
+			mock := &Mocker{BasePath: ":", Client: http.DefaultClient}
 			results, err := mock.Results()
 
-			So(err.Error(), ShouldEqual, "parse :/mocks: missing protocol scheme")
+			So(err.Error(), ShouldEqual, `parse ":/mocks": missing protocol scheme`)
 			So(results, ShouldBeNil)
 		})
 
 		Convey("Returns an error when it's not possible to execute the request", func() {
-			mock := &Mocker{BasePath: "foo://bar"}
+			mock := &Mocker{BasePath: "foo://bar", Client: http.DefaultClient}
 			results, err := mock.Results()
 
-			So(err.Error(), ShouldEqual, `Get foo://bar/mocks: unsupported protocol scheme "foo"`)
+			So(err.Error(), ShouldEqual, `Get "foo://bar/mocks": unsupported protocol scheme "foo"`)
 			So(results, ShouldBeNil)
 		})
 
@@ -61,7 +62,7 @@ func Test_Mocker_Results(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			results, err := mock.Results()
 
 			So(err.Error(), ShouldEqual, "failed to get mocks")
@@ -83,7 +84,7 @@ func Test_Mocker_Results(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			results, err := mock.Results()
 
 			So(err.Error(), ShouldEqual, "invalid character 'o' in literal false (expecting 'a')")
@@ -104,7 +105,7 @@ func Test_Mocker_Results(t *testing.T) {
 					fmt.Fprintf(w, `{"expected":[],"unexpected":[]}`)
 				})
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			results, err := mock.Results()
 
 			So(err, ShouldBeNil)
@@ -145,7 +146,7 @@ func Test_Mocker_Ensure(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Ensure()
 
 			So(strings.Join(strings.Fields(err.Error()), " "), ShouldEqual, `missing 1 expected calls: [ { "method": "", "path": "", "response": null } ]`)
@@ -173,7 +174,7 @@ func Test_Mocker_Ensure(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Ensure()
 
 			So(strings.Join(strings.Fields(err.Error()), " "), ShouldEqual, `1 unexpected calls: [ { "method": "", "path": "", "response": null } ]`)
@@ -202,7 +203,7 @@ func Test_Mocker_Ensure(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Ensure()
 
 			So(err, ShouldBeNil)
@@ -220,17 +221,17 @@ func Test_Mocker_Expect(t *testing.T) {
 
 	Convey("*Mocker.Expect()", t, func() {
 		Convey("Returns an error when it's not possible to create a request", func() {
-			mock := &Mocker{BasePath: ":"}
+			mock := &Mocker{BasePath: ":", Client: http.DefaultClient}
 			err := mock.Expect(nil)
 
-			So(err.Error(), ShouldEqual, "parse :/mocks: missing protocol scheme")
+			So(err.Error(), ShouldEqual, `parse ":/mocks": missing protocol scheme`)
 		})
 
 		Convey("Returns an error when it's not possible to execute the request", func() {
-			mock := &Mocker{}
+			mock := &Mocker{Client: http.DefaultClient}
 			err := mock.Expect(nil)
 
-			So(err.Error(), ShouldEqual, `Post /mocks: unsupported protocol scheme ""`)
+			So(err.Error(), ShouldEqual, `Post "/mocks": unsupported protocol scheme ""`)
 		})
 
 		Convey("Does not fail when the request returns 201", func() {
@@ -248,7 +249,7 @@ func Test_Mocker_Expect(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Expect(&Request{
 				Query: map[string][]string{
 					"biz": []string{"baz"},
@@ -283,7 +284,7 @@ func Test_Mocker_Expect(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Expect(&Request{
 				Query: map[string][]string{
 					"biz": []string{"baz"},
@@ -312,17 +313,17 @@ func Test_Mocker_Clear(t *testing.T) {
 
 	Convey("*Mocker.Clear()", t, func() {
 		Convey("Returns an error when it's not possible to create a request", func() {
-			mock := &Mocker{BasePath: ":"}
+			mock := &Mocker{BasePath: ":", Client: http.DefaultClient}
 			err := mock.Clear()
 
-			So(err.Error(), ShouldEqual, "parse :/mocks: missing protocol scheme")
+			So(err.Error(), ShouldEqual, `parse ":/mocks": missing protocol scheme`)
 		})
 
 		Convey("Returns an error when it's not possible to execute the request", func() {
-			mock := &Mocker{}
+			mock := &Mocker{Client: http.DefaultClient}
 			err := mock.Clear()
 
-			So(err.Error(), ShouldEqual, `Delete /mocks: unsupported protocol scheme ""`)
+			So(err.Error(), ShouldEqual, `Delete "/mocks": unsupported protocol scheme ""`)
 		})
 
 		Convey("It fails when the request does not return 200", func() {
@@ -338,7 +339,7 @@ func Test_Mocker_Clear(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Clear()
 
 			So(err.Error(), ShouldEqual, "failed to clear mocks")
@@ -359,7 +360,7 @@ func Test_Mocker_Clear(t *testing.T) {
 				}).
 				Times(1)
 
-			mock := &Mocker{BasePath: server.URL}
+			mock := &Mocker{BasePath: server.URL, Client: http.DefaultClient}
 			err := mock.Clear()
 
 			So(err, ShouldBeNil)


### PR DESCRIPTION
Uses a http client with a 1 second timeout since `http.DefaultClient` has no default timeout